### PR TITLE
Keep the button position when it's placed right before space, flexible space or separator

### DIFF
--- a/src/lib/customizableUI.js
+++ b/src/lib/customizableUI.js
@@ -93,11 +93,19 @@ function restoreWidget(/**Element*/ toolbox, /**Widget*/ widget)
 
 function showWidget(/**Element*/ toolbox, /**Widget*/ widget, /**String*/ position)
 {
-  let visible = "visible", parent = null, before = null;
+  let visible = "visible", parent = null, before = null, special = null;
   if (position)
   {
     [visible, parent, before] = position.split(",", 3);
     parent = toolbox.ownerDocument.getElementById(parent);
+    // Handle special items with dynamic ids
+    special = /^(separator|spacer|spring)\[(\d+)\]$/.exec(before);
+    if (special !== null) {
+      let dynItems = parent.querySelectorAll("toolbar" + special[1]);
+      if (special[2] < dynItems.length) {
+        before = dynItems[special[2]].id;
+      }
+    }
     if (before == "")
       before = null;
     else
@@ -133,7 +141,8 @@ function showWidget(/**Element*/ toolbox, /**Widget*/ widget, /**String*/ positi
   {
     // Add the item to the toolbar
     let items = parent.currentSet.split(",");
-    let index = (before ? items.indexOf(before.id) : -1);
+    let beforeId = (special ? special[1] : before.id);
+    let index = (before ? items.indexOf(beforeId) : -1);
     if (index < 0)
       before = null;
     parent.insertItem(widget.id, before, null, false);
@@ -175,7 +184,19 @@ function saveState(/**Element*/ toolbox, /**Widget*/ widget)
       widget.onAdded(node)
 
     let toolbar = getToolbar(node);
-    position = "visible," + toolbar.id + "," + (node.nextSibling ? node.nextSibling.id : "");
+    // Handle special items with dynamic ids
+    let nextSiblingId = node.nextSibling && node.nextSibling.id;
+    let special = /^(separator|spacer|spring)\d+$/.exec(nextSiblingId);
+    if (special !== null) {
+      let dynItems = node.nextSibling.parentNode.querySelectorAll("toolbar" + special[1]);
+      for (let i = 0; i < dynItems.length; i++) {
+        if (dynItems[i].id == nextSiblingId) {
+          nextSiblingId = special[1] + "[" + i + "]";
+          break;
+        }
+      }
+    }
+    position = "visible," + toolbar.id + "," + (node.nextSibling ? nextSiblingId : "");
   }
   else
     position = position.replace(/^visible,/, "hidden,")


### PR DESCRIPTION
Consider the fact the ids for the spacer, separator and spring toolbar elements are dynamically generated.



This resolves the issue [reported on the forum](https://forum.palemoon.org/viewtopic.php?f=3&t=23419) (based on https://github.com/MoonchildProductions/UXP/pull/579).
